### PR TITLE
Add ability to use super attack and super strength if super combat is not in user's bank for TOA

### DIFF
--- a/src/lib/simulation/toa.ts
+++ b/src/lib/simulation/toa.ts
@@ -183,8 +183,7 @@ const minTOAStats: Skills = {
 const minimumSuppliesNeeded = new Bank({
 	'Saradomin brew(4)': 10,
 	'Super restore(4)': 5,
-	'Ranging potion(4)': 1,
-	'Super combat potion(4)': 1
+	'Ranging potion(4)': 1
 });
 
 const miscBoosts = [
@@ -320,6 +319,12 @@ const toaRequirements: {
 	{
 		name: 'Supplies',
 		doesMeet: ({ user, quantity }) => {
+			if (user.owns(new Bank().add('Super combat potion(4)', 1))) {
+				minimumSuppliesNeeded.add('Super combat potion(4)', 1);
+			} else {
+				minimumSuppliesNeeded.add('Super attack(4)', 1);
+				minimumSuppliesNeeded.add('Super strength(4)', 1);
+			}
 			if (!user.owns(minimumSuppliesNeeded.clone().multiply(quantity))) {
 				return `You need atleast this much supplies: ${minimumSuppliesNeeded}.`;
 			}
@@ -953,7 +958,12 @@ async function calcTOAInput({
 }> {
 	const cost = new Bank();
 	const kc = kcOverride ?? (await getMinigameScore(user.id, 'tombs_of_amascut'));
-	cost.add('Super combat potion(4)', quantity);
+	if (minimumSuppliesNeeded.has('Super combat potion(4)')) {
+		cost.add('Super combat potion(4)');
+	} else if (minimumSuppliesNeeded.has('Super attack(4)') && minimumSuppliesNeeded.has('Super strength(4)')) {
+		cost.add('Super attack potion(4)', quantity);
+		cost.add('Super strength(4)', quantity);
+	}
 	cost.add('Ranging potion(4)', quantity);
 
 	let serpHelmCharges = 0;


### PR DESCRIPTION
### Description:

Added logic to check if user has a super combat, if available add that to `minimumSuppliesNeeded` and then continue like before. Else add a super attack and super strength and then continue like before with all of the requirement checks.

### Changes:
Changes in toa.ts only. To minimum supplies and condition check before checking minimumSuppliesNeeded against the bank. As well as adding the supplies to the cost accordingly.

### Other checks:

- [x] I have tested all my changes thoroughly.
